### PR TITLE
Bring WPCOM-specific customizations from coblocks-builder

### DIFF
--- a/class-coblocks.php
+++ b/class-coblocks.php
@@ -105,32 +105,42 @@ if ( ! class_exists( 'CoBlocks' ) ) :
 			require_once COBLOCKS_PLUGIN_DIR . 'includes/class-coblocks-register-blocks.php';
 			require_once COBLOCKS_PLUGIN_DIR . 'includes/class-coblocks-generated-styles.php';
 			require_once COBLOCKS_PLUGIN_DIR . 'includes/class-coblocks-body-classes.php';
-			require_once COBLOCKS_PLUGIN_DIR . 'includes/class-coblocks-form.php';
+			// WP.com custom - START
+			// require_once COBLOCKS_PLUGIN_DIR . 'includes/class-coblocks-form.php';
+			// WP.com custom - END
 			require_once COBLOCKS_PLUGIN_DIR . 'includes/class-coblocks-font-loader.php';
 			require_once COBLOCKS_PLUGIN_DIR . 'includes/class-coblocks-post-meta.php';
-			require_once COBLOCKS_PLUGIN_DIR . 'includes/class-coblocks-google-map-block.php';
-			require_once COBLOCKS_PLUGIN_DIR . 'includes/class-coblocks-accordion-ie-support.php';
+			// WP.com custom - START
+			// require_once COBLOCKS_PLUGIN_DIR . 'includes/class-coblocks-google-map-block.php';
+			// require_once COBLOCKS_PLUGIN_DIR . 'includes/class-coblocks-accordion-ie-support.php';
+			// WP.com custom - END
 			require_once COBLOCKS_PLUGIN_DIR . 'includes/class-coblocks-settings.php';
-			require_once COBLOCKS_PLUGIN_DIR . 'includes/get-dynamic-blocks.php';
-			require_once COBLOCKS_PLUGIN_DIR . 'includes/ical-parser/class-coblocks-event.php';
-			require_once COBLOCKS_PLUGIN_DIR . 'includes/ical-parser/class-coblocks-ical.php';
+			// WP.com custom - START
+			// require_once COBLOCKS_PLUGIN_DIR . 'includes/get-dynamic-blocks.php';
+			// require_once COBLOCKS_PLUGIN_DIR . 'includes/ical-parser/class-coblocks-event.php';
+			// require_once COBLOCKS_PLUGIN_DIR . 'includes/ical-parser/class-coblocks-ical.php';
+			// WP.com custom - END
 
+			// WP.com custom - START
 			// Require the Gutenberg plugin for specific components.
-			include_once ABSPATH . 'wp-admin/includes/plugin.php';
-			$installed_plugins = get_plugins();
+			// include_once ABSPATH . 'wp-admin/includes/plugin.php';
+			// $installed_plugins = get_plugins();
 
-			$gutenberg_plugin_file    = 'gutenberg/gutenberg.php';
-			$gutenberg_plugin_version = empty( $installed_plugins[ $gutenberg_plugin_file ] ) ? null : $installed_plugins[ $gutenberg_plugin_file ]['Version'];
+			// $gutenberg_plugin_file    = 'gutenberg/gutenberg.php';
+			// $gutenberg_plugin_version = empty( $installed_plugins[ $gutenberg_plugin_file ] ) ? null : $installed_plugins[ $gutenberg_plugin_file ]['Version'];
 
-			if ( is_admin() && is_plugin_active( $gutenberg_plugin_file ) && version_compare( $gutenberg_plugin_version, '8.0.0', '>=' ) ) {
-				require_once COBLOCKS_PLUGIN_DIR . 'src/extensions/layout-selector/index.php';
-			}
+			// if ( is_admin() && is_plugin_active( $gutenberg_plugin_file ) && version_compare( $gutenberg_plugin_version, '8.0.0', '>=' ) ) {
+			// 	require_once COBLOCKS_PLUGIN_DIR . 'src/extensions/layout-selector/index.php';
+			// }
+			// WP.com custom - END
 
-			if ( is_admin() || ( defined( 'WP_CLI' ) && WP_CLI ) ) {
-				require_once COBLOCKS_PLUGIN_DIR . 'includes/admin/class-coblocks-action-links.php';
-				require_once COBLOCKS_PLUGIN_DIR . 'includes/admin/class-coblocks-install.php';
-				require_once COBLOCKS_PLUGIN_DIR . 'includes/admin/class-coblocks-crop-settings.php';
-			}
+			// WP.com custom - START
+			// if ( is_admin() || ( defined( 'WP_CLI' ) && WP_CLI ) ) {
+				// require_once COBLOCKS_PLUGIN_DIR . 'includes/admin/class-coblocks-action-links.php';
+				// require_once COBLOCKS_PLUGIN_DIR . 'includes/admin/class-coblocks-install.php';
+				// require_once COBLOCKS_PLUGIN_DIR . 'includes/admin/class-coblocks-crop-settings.php';
+			// }
+			// WP.com custom - END
 		}
 
 		/**

--- a/class-coblocks.php
+++ b/class-coblocks.php
@@ -105,42 +105,9 @@ if ( ! class_exists( 'CoBlocks' ) ) :
 			require_once COBLOCKS_PLUGIN_DIR . 'includes/class-coblocks-register-blocks.php';
 			require_once COBLOCKS_PLUGIN_DIR . 'includes/class-coblocks-generated-styles.php';
 			require_once COBLOCKS_PLUGIN_DIR . 'includes/class-coblocks-body-classes.php';
-			// WP.com custom - START
-			// require_once COBLOCKS_PLUGIN_DIR . 'includes/class-coblocks-form.php';
-			// WP.com custom - END
 			require_once COBLOCKS_PLUGIN_DIR . 'includes/class-coblocks-font-loader.php';
 			require_once COBLOCKS_PLUGIN_DIR . 'includes/class-coblocks-post-meta.php';
-			// WP.com custom - START
-			// require_once COBLOCKS_PLUGIN_DIR . 'includes/class-coblocks-google-map-block.php';
-			// require_once COBLOCKS_PLUGIN_DIR . 'includes/class-coblocks-accordion-ie-support.php';
-			// WP.com custom - END
 			require_once COBLOCKS_PLUGIN_DIR . 'includes/class-coblocks-settings.php';
-			// WP.com custom - START
-			// require_once COBLOCKS_PLUGIN_DIR . 'includes/get-dynamic-blocks.php';
-			// require_once COBLOCKS_PLUGIN_DIR . 'includes/ical-parser/class-coblocks-event.php';
-			// require_once COBLOCKS_PLUGIN_DIR . 'includes/ical-parser/class-coblocks-ical.php';
-			// WP.com custom - END
-
-			// WP.com custom - START
-			// Require the Gutenberg plugin for specific components.
-			// include_once ABSPATH . 'wp-admin/includes/plugin.php';
-			// $installed_plugins = get_plugins();
-
-			// $gutenberg_plugin_file    = 'gutenberg/gutenberg.php';
-			// $gutenberg_plugin_version = empty( $installed_plugins[ $gutenberg_plugin_file ] ) ? null : $installed_plugins[ $gutenberg_plugin_file ]['Version'];
-
-			// if ( is_admin() && is_plugin_active( $gutenberg_plugin_file ) && version_compare( $gutenberg_plugin_version, '8.0.0', '>=' ) ) {
-			// 	require_once COBLOCKS_PLUGIN_DIR . 'src/extensions/layout-selector/index.php';
-			// }
-			// WP.com custom - END
-
-			// WP.com custom - START
-			// if ( is_admin() || ( defined( 'WP_CLI' ) && WP_CLI ) ) {
-				// require_once COBLOCKS_PLUGIN_DIR . 'includes/admin/class-coblocks-action-links.php';
-				// require_once COBLOCKS_PLUGIN_DIR . 'includes/admin/class-coblocks-install.php';
-				// require_once COBLOCKS_PLUGIN_DIR . 'includes/admin/class-coblocks-crop-settings.php';
-			// }
-			// WP.com custom - END
 		}
 
 		/**

--- a/includes/class-coblocks-block-assets.php
+++ b/includes/class-coblocks-block-assets.php
@@ -154,7 +154,10 @@ class CoBlocks_Block_Assets {
 			true
 		);
 
-		$post_id = filter_input( INPUT_GET, 'post', FILTER_SANITIZE_NUMBER_INT );
+		// WP.com custom - START
+		$post_id    = filter_input( INPUT_GET, 'post', FILTER_SANITIZE_NUMBER_INT );
+		$post_title = get_bloginfo( 'name' ) . ( ( false === $post_id ) ? '' : sprintf( ' - %s', get_the_title( $post_id ) ) );
+		// WP.com custom - END
 
 		/**
 		 * Filter the default block email address value
@@ -179,7 +182,9 @@ class CoBlocks_Block_Assets {
 		 */
 		$bundled_icons_enabled = (bool) apply_filters( 'coblocks_bundled_icons_enabled', true );
 
-		$form_subject = ( new CoBlocks_Form() )->default_subject();
+		// WP.com custom - START
+		// $form_subject = ( new CoBlocks_Form() )->default_subject();
+		// WP.com custom - END
 
 		wp_localize_script(
 			'coblocks-editor',
@@ -187,7 +192,10 @@ class CoBlocks_Block_Assets {
 			array(
 				'form'                           => array(
 					'adminEmail'   => $email_to,
-					'emailSubject' => $form_subject,
+					// WP.com custom - START
+					// 'emailSubject' => $form_subject,
+					'emailSubject' => $post_title,
+					// WP.com custom - END
 				),
 				'cropSettingsOriginalImageNonce' => wp_create_nonce( 'cropSettingsOriginalImageNonce' ),
 				'cropSettingsNonce'              => wp_create_nonce( 'cropSettingsNonce' ),
@@ -284,9 +292,11 @@ class CoBlocks_Block_Assets {
 	public function frontend_scripts() {
 
 		// Custom scripts are not allowed in AMP, so short-circuit.
-		if ( CoBlocks()->is_amp() ) {
-			return;
-		}
+		// WP.com custom - START
+		// if ( CoBlocks()->is_amp() ) {
+		// 	return;
+		// }
+		// WP.com custom - END
 
 		// Define where the asset is loaded from.
 		$dir = CoBlocks()->asset_source( 'js' );
@@ -305,6 +315,12 @@ class CoBlocks_Block_Assets {
 			);
 		}
 
+		// WP.com custom - START
+		/*
+			DISABLED ON WPCOM
+			These blocks are unavailable and should not have their assets enqueued.
+			See customization in blocks.js.
+			These sections check for `core/block` (reusable blocks) and enqueue assets that are not necessary.
 		// Carousel block.
 		if ( has_block( 'coblocks/gallery-carousel' ) || has_block( 'core/block' ) ) {
 			wp_enqueue_script(
@@ -361,6 +377,9 @@ class CoBlocks_Block_Assets {
 				true
 			);
 		}
+
+		*/
+		// WP.com custom - END
 
 		// Lightbox.
 		if (

--- a/includes/class-coblocks-block-assets.php
+++ b/includes/class-coblocks-block-assets.php
@@ -182,20 +182,13 @@ class CoBlocks_Block_Assets {
 		 */
 		$bundled_icons_enabled = (bool) apply_filters( 'coblocks_bundled_icons_enabled', true );
 
-		// WP.com custom - START
-		// $form_subject = ( new CoBlocks_Form() )->default_subject();
-		// WP.com custom - END
-
 		wp_localize_script(
 			'coblocks-editor',
 			'coblocksBlockData',
 			array(
 				'form'                           => array(
 					'adminEmail'   => $email_to,
-					// WP.com custom - START
-					// 'emailSubject' => $form_subject,
 					'emailSubject' => $post_title,
-					// WP.com custom - END
 				),
 				'cropSettingsOriginalImageNonce' => wp_create_nonce( 'cropSettingsOriginalImageNonce' ),
 				'cropSettingsNonce'              => wp_create_nonce( 'cropSettingsNonce' ),
@@ -290,14 +283,6 @@ class CoBlocks_Block_Assets {
 	 * @since 1.9.5
 	 */
 	public function frontend_scripts() {
-
-		// Custom scripts are not allowed in AMP, so short-circuit.
-		// WP.com custom - START
-		// if ( CoBlocks()->is_amp() ) {
-		// 	return;
-		// }
-		// WP.com custom - END
-
 		// Define where the asset is loaded from.
 		$dir = CoBlocks()->asset_source( 'js' );
 
@@ -314,72 +299,6 @@ class CoBlocks_Block_Assets {
 				true
 			);
 		}
-
-		// WP.com custom - START
-		/*
-			DISABLED ON WPCOM
-			These blocks are unavailable and should not have their assets enqueued.
-			See customization in blocks.js.
-			These sections check for `core/block` (reusable blocks) and enqueue assets that are not necessary.
-		// Carousel block.
-		if ( has_block( 'coblocks/gallery-carousel' ) || has_block( 'core/block' ) ) {
-			wp_enqueue_script(
-				'coblocks-flickity',
-				$vendors_dir . '/flickity.js',
-				array( 'jquery' ),
-				COBLOCKS_VERSION,
-				true
-			);
-
-			if ( has_block( 'coblocks/accordion' ) || has_block( 'core/block' ) ) {
-				wp_enqueue_script(
-					'coblocks-accordion-carousel',
-					$dir . 'coblocks-accordion-carousel.js',
-					array( 'coblocks-flickity' ),
-					COBLOCKS_VERSION,
-					true
-				);
-			}
-		}
-
-		// Post Carousel block.
-		if ( has_block( 'coblocks/post-carousel' ) || has_block( 'core/block' ) ) {
-			wp_enqueue_script(
-				'coblocks-slick',
-				$vendors_dir . '/slick.js',
-				array( 'jquery' ),
-				COBLOCKS_VERSION,
-				true
-			);
-			wp_enqueue_script(
-				'coblocks-slick-initializer-front',
-				$dir . 'coblocks-slick-initializer-front.js',
-				array( 'jquery' ),
-				COBLOCKS_VERSION,
-				true
-			);
-		}
-
-		// Events block.
-		if ( has_block( 'coblocks/events' ) || has_block( 'core/block' ) ) {
-			wp_enqueue_script(
-				'coblocks-slick',
-				$vendors_dir . '/slick.js',
-				array( 'jquery' ),
-				COBLOCKS_VERSION,
-				true
-			);
-			wp_enqueue_script(
-				'coblocks-events',
-				$dir . 'coblocks-events.js',
-				array( 'jquery' ),
-				COBLOCKS_VERSION,
-				true
-			);
-		}
-
-		*/
-		// WP.com custom - END
 
 		// Lightbox.
 		if (

--- a/includes/class-coblocks-block-assets.php
+++ b/includes/class-coblocks-block-assets.php
@@ -154,10 +154,8 @@ class CoBlocks_Block_Assets {
 			true
 		);
 
-		// WP.com custom - START
 		$post_id    = filter_input( INPUT_GET, 'post', FILTER_SANITIZE_NUMBER_INT );
 		$post_title = get_bloginfo( 'name' ) . ( ( false === $post_id ) ? '' : sprintf( ' - %s', get_the_title( $post_id ) ) );
-		// WP.com custom - END
 
 		/**
 		 * Filter the default block email address value

--- a/includes/class-coblocks-register-blocks.php
+++ b/includes/class-coblocks-register-blocks.php
@@ -69,34 +69,6 @@ class CoBlocks_Register_Blocks {
 		// Shortcut for the slug.
 		$slug = $this->slug;
 
-		// WP.com custom - START
-		/*
-		register_block_type(
-			$slug . '/accordion',
-			array(
-				'editor_script' => $slug . '-editor',
-				'editor_style'  => $slug . '-editor',
-				'style'         => $slug . '-frontend',
-			)
-		);
-		register_block_type(
-			$slug . '/alert',
-			array(
-				'editor_script' => $slug . '-editor',
-				'editor_style'  => $slug . '-editor',
-				'style'         => $slug . '-frontend',
-			)
-		);
-		register_block_type(
-			$slug . '/author',
-			array(
-				'editor_script' => $slug . '-editor',
-				'editor_style'  => $slug . '-editor',
-				'style'         => $slug . '-frontend',
-			)
-		);
-		*/
-		// WP.com custom - END
 		register_block_type(
 			$slug . '/click-to-tweet',
 			array(
@@ -113,42 +85,6 @@ class CoBlocks_Register_Blocks {
 				'style'         => $slug . '-frontend',
 			)
 		);
-		// WP.com custom - START
-		/*
-		register_block_type(
-			$slug . '/gif',
-			array(
-				'editor_script' => $slug . '-editor',
-				'editor_style'  => $slug . '-editor',
-				'style'         => $slug . '-frontend',
-			)
-		);
-		register_block_type(
-			$slug . '/gist',
-			array(
-				'editor_script' => $slug . '-editor',
-				'editor_style'  => $slug . '-editor',
-				'style'         => $slug . '-frontend',
-			)
-		);
-		register_block_type(
-			$slug . '/highlight',
-			array(
-				'editor_script' => $slug . '-editor',
-				'editor_style'  => $slug . '-editor',
-				'style'         => $slug . '-frontend',
-			)
-		);
-		register_block_type(
-			$slug . '/gallery-carousel',
-			array(
-				'editor_script' => $slug . '-editor',
-				'editor_style'  => $slug . '-editor',
-				'style'         => $slug . '-frontend',
-			)
-		);
-		*/
-		// WP.com custom - END
 		register_block_type(
 			$slug . '/gallery-masonry',
 			array(

--- a/includes/class-coblocks-register-blocks.php
+++ b/includes/class-coblocks-register-blocks.php
@@ -69,6 +69,8 @@ class CoBlocks_Register_Blocks {
 		// Shortcut for the slug.
 		$slug = $this->slug;
 
+		// WP.com custom - START
+		/*
 		register_block_type(
 			$slug . '/accordion',
 			array(
@@ -93,6 +95,8 @@ class CoBlocks_Register_Blocks {
 				'style'         => $slug . '-frontend',
 			)
 		);
+		*/
+		// WP.com custom - END
 		register_block_type(
 			$slug . '/click-to-tweet',
 			array(
@@ -109,6 +113,8 @@ class CoBlocks_Register_Blocks {
 				'style'         => $slug . '-frontend',
 			)
 		);
+		// WP.com custom - START
+		/*
 		register_block_type(
 			$slug . '/gif',
 			array(
@@ -141,6 +147,8 @@ class CoBlocks_Register_Blocks {
 				'style'         => $slug . '-frontend',
 			)
 		);
+		*/
+		// WP.com custom - END
 		register_block_type(
 			$slug . '/gallery-masonry',
 			array(

--- a/src/blocks.js
+++ b/src/blocks.js
@@ -15,31 +15,10 @@ import { __, sprintf } from '@wordpress/i18n';
 import './utils/block-category';
 
 // Extensions
-// WP.com custom - START
-// import './extensions/colors/inspector';
-// import './extensions/typography';
-// WP.com custom - END
 import './extensions/attributes';
-// WP.com custom - START
-// import './extensions/advanced-controls';
-// import './extensions/padding-controls';
-// import './extensions/list-styles';
-// import './extensions/button-styles';
-// import './extensions/button-controls';
-// import './extensions/image-styles';
-// WP.com custom - END
 import './extensions/cover-styles';
-// WP.com custom - START
-// import './extensions/lightbox-controls';
-// WP.com custom - END
 import './extensions/replace-image';
-// WP.com custom - START
-// import './extensions/image-crop';
-// WP.com custom - END
 import './extensions/coblocks-settings/';
-// WP.com custom - START
-// import './extensions/layout-selector';
-// WP.com custom - END
 
 // Formats
 import './formats';
@@ -51,73 +30,16 @@ import { supportsCollections } from './utils/block-helpers';
 import './js/deprecations/deprecate-coblocks-buttons.js';
 
 // Register Blocks
-// WP.com custom - START
-// import * as accordion from './blocks/accordion';
-// import * as accordionItem from './blocks/accordion/accordion-item';
-// import * as alert from './blocks/alert';
-// import * as author from './blocks/author';
-// WP.com custom - END
 import * as buttons from './blocks/buttons';
-// WP.com custom - START
-// import * as carousel from './blocks/gallery-carousel';
-// WP.com custom - END
 import * as clickToTweet from './blocks/click-to-tweet';
 import * as collage from './blocks/gallery-collage';
-// WP.com custom - START
-// import * as column from './blocks/row/column';
-// WP.com custom - END
 import * as dynamicSeparator from './blocks/dynamic-separator';
-// WP.com custom - START
-// import * as events from './blocks/events';
-// import * as eventItem from './blocks/events/event-item';
-// import * as feature from './blocks/features/feature';
-// import * as features from './blocks/features';
-// import * as foodAndDrinks from './blocks/food-and-drinks';
-// import * as foodItem from './blocks/food-and-drinks/food-item';
-// import * as form from './blocks/form';
-// import * as fieldDate from './blocks/form/fields/date';
-// import * as fieldEmail from './blocks/form/fields/email';
-// import * as fieldName from './blocks/form/fields/name';
-// import * as fieldRadio from './blocks/form/fields/radio';
-// import * as fieldTelephone from './blocks/form/fields/phone';
-// import * as fieldTextarea from './blocks/form/fields/textarea';
-// import * as fieldText from './blocks/form/fields/text';
-// import * as fieldSelect from './blocks/form/fields/select';
-// import * as fieldSubmitButton from './blocks/form/fields/submit-button';
-// import * as fieldCheckbox from './blocks/form/fields/checkbox';
-// import * as fieldWebsite from './blocks/form/fields/website';
-// import * as fieldHidden from './blocks/form/fields/hidden';
-// import * as gif from './blocks/gif';
-// import * as gist from './blocks/gist';
-// WP.com custom - END
 import * as hero from './blocks/hero';
-// WP.com custom - START
-// import * as highlight from './blocks/highlight';
-// import * as icon from './blocks/icon';
-// WP.com custom - END
 import * as logos from './blocks/logos';
-// WP.com custom - START
-// import * as map from './blocks/map';
-// WP.com custom - END
 import * as masonry from './blocks/gallery-masonry';
-// WP.com custom - START
-// import * as mediaCard from './blocks/media-card';
-// WP.com custom - END
 import * as offset from './blocks/gallery-offset';
-// WP.com custom - START
-// import * as posts from './blocks/posts';
-// import * as postCarousel from './blocks/post-carousel';
-// WP.com custom - END
 import * as pricingTable from './blocks/pricing-table';
 import * as pricingTableItem from './blocks/pricing-table/pricing-table-item';
-// WP.com custom - START
-// import * as row from './blocks/row';
-// import * as services from './blocks/services';
-// import * as service from './blocks/services/service';
-// import * as shapeDivider from './blocks/shape-divider';
-// import * as share from './blocks/share';
-// import * as socialProfiles from './blocks/social-profiles';
-// WP.com custom - END
 import * as stacked from './blocks/gallery-stacked';
 
 /**
@@ -136,10 +58,6 @@ const registerBlock = ( block ) => {
 	const { name, settings } = block;
 
 	// WP.com custom - START
-	//if ( ! supportsCollections() && ! name.includes( 'gallery' ) ) {
-	//	category = 'coblocks';
-	//}
-
 	// See https://github.com/Automattic/jetpack/issues/14598
 	const availableCategories = wp.blocks.getCategories().map( category => category.slug );
 	switch ( name ) {
@@ -179,73 +97,16 @@ const registerBlock = ( block ) => {
  */
 export const registerCoBlocksBlocks = () => {
 	[
-		// WP.com custom - START
-		// accordion,
-		// accordionItem,
-		// alert,
-		// author,
-		// WP.com custom - END
 		buttons,
-		// WP.com custom - START
-		// carousel,
-		// WP.com custom - END
 		clickToTweet,
 		collage,
-		// WP.com custom - START
-		// column,
-		// WP.com custom - END
 		dynamicSeparator,
-		// WP.com custom - START
-		// events,
-		// eventItem,
-		// feature,
-		// features,
-		// fieldDate,
-		// fieldEmail,
-		// fieldName,
-		// fieldRadio,
-		// fieldTelephone,
-		// fieldTextarea,
-		// fieldText,
-		// fieldSelect,
-		// fieldSubmitButton
-		// fieldCheckbox,
-		// fieldWebsite,
-		// fieldHidden,
-		// foodAndDrinks,
-		// foodItem,
-		// form,
-		// gif,
-		// gist,
-		// WP.com custom - END
 		hero,
-		// WP.com custom - START
-		// highlight,
-		// icon,
-		// WP.com custom - END
 		logos,
-		// WP.com custom - START
-		// map,
-		// WP.com custom - END
 		masonry,
-		// WP.com custom - START
-		// mediaCard,
-		// WP.com custom - END
 		offset,
-		// WP.com custom - START
-		// posts,
-		// postCarousel,
-		// WP.com custom - END
 		pricingTable,
 		pricingTableItem,
-		// WP.com custom - START
-		// row,
-		// service,
-		// services,
-		// shapeDivider,
-		// share,
-		// socialProfiles,
-		// WP.com custom - END
 		stacked,
 	].forEach( registerBlock );
 };

--- a/src/blocks.js
+++ b/src/blocks.js
@@ -2,28 +2,44 @@
  * WordPress dependencies
  */
 import {
+	// WP.com custom - START
+	getCategories,
+	// WP.com custom - END
 	registerBlockType,
 } from '@wordpress/blocks';
+// WP.com custom - START
+import { __, sprintf } from '@wordpress/i18n';
+// WP.com custom - END
 
 // Register block category
 import './utils/block-category';
 
 // Extensions
-import './extensions/colors/inspector';
-import './extensions/typography';
+// WP.com custom - START
+// import './extensions/colors/inspector';
+// import './extensions/typography';
+// WP.com custom - END
 import './extensions/attributes';
-import './extensions/advanced-controls';
-import './extensions/padding-controls';
-import './extensions/list-styles';
-import './extensions/button-styles';
-import './extensions/button-controls';
-import './extensions/image-styles';
+// WP.com custom - START
+// import './extensions/advanced-controls';
+// import './extensions/padding-controls';
+// import './extensions/list-styles';
+// import './extensions/button-styles';
+// import './extensions/button-controls';
+// import './extensions/image-styles';
+// WP.com custom - END
 import './extensions/cover-styles';
-import './extensions/lightbox-controls';
+// WP.com custom - START
+// import './extensions/lightbox-controls';
+// WP.com custom - END
 import './extensions/replace-image';
-import './extensions/image-crop';
+// WP.com custom - START
+// import './extensions/image-crop';
+// WP.com custom - END
 import './extensions/coblocks-settings/';
-import './extensions/layout-selector';
+// WP.com custom - START
+// import './extensions/layout-selector';
+// WP.com custom - END
 
 // Formats
 import './formats';
@@ -35,55 +51,73 @@ import { supportsCollections } from './utils/block-helpers';
 import './js/deprecations/deprecate-coblocks-buttons.js';
 
 // Register Blocks
-import * as accordion from './blocks/accordion';
-import * as accordionItem from './blocks/accordion/accordion-item';
-import * as alert from './blocks/alert';
-import * as author from './blocks/author';
+// WP.com custom - START
+// import * as accordion from './blocks/accordion';
+// import * as accordionItem from './blocks/accordion/accordion-item';
+// import * as alert from './blocks/alert';
+// import * as author from './blocks/author';
+// WP.com custom - END
 import * as buttons from './blocks/buttons';
-import * as carousel from './blocks/gallery-carousel';
+// WP.com custom - START
+// import * as carousel from './blocks/gallery-carousel';
+// WP.com custom - END
 import * as clickToTweet from './blocks/click-to-tweet';
 import * as collage from './blocks/gallery-collage';
-import * as column from './blocks/row/column';
+// WP.com custom - START
+// import * as column from './blocks/row/column';
+// WP.com custom - END
 import * as dynamicSeparator from './blocks/dynamic-separator';
-import * as events from './blocks/events';
-import * as eventItem from './blocks/events/event-item';
-import * as feature from './blocks/features/feature';
-import * as features from './blocks/features';
-import * as foodAndDrinks from './blocks/food-and-drinks';
-import * as foodItem from './blocks/food-and-drinks/food-item';
-import * as form from './blocks/form';
-import * as fieldDate from './blocks/form/fields/date';
-import * as fieldEmail from './blocks/form/fields/email';
-import * as fieldName from './blocks/form/fields/name';
-import * as fieldRadio from './blocks/form/fields/radio';
-import * as fieldTelephone from './blocks/form/fields/phone';
-import * as fieldTextarea from './blocks/form/fields/textarea';
-import * as fieldText from './blocks/form/fields/text';
-import * as fieldSelect from './blocks/form/fields/select';
-import * as fieldSubmitButton from './blocks/form/fields/submit-button';
-import * as fieldCheckbox from './blocks/form/fields/checkbox';
-import * as fieldWebsite from './blocks/form/fields/website';
-import * as fieldHidden from './blocks/form/fields/hidden';
-import * as gif from './blocks/gif';
-import * as gist from './blocks/gist';
+// WP.com custom - START
+// import * as events from './blocks/events';
+// import * as eventItem from './blocks/events/event-item';
+// import * as feature from './blocks/features/feature';
+// import * as features from './blocks/features';
+// import * as foodAndDrinks from './blocks/food-and-drinks';
+// import * as foodItem from './blocks/food-and-drinks/food-item';
+// import * as form from './blocks/form';
+// import * as fieldDate from './blocks/form/fields/date';
+// import * as fieldEmail from './blocks/form/fields/email';
+// import * as fieldName from './blocks/form/fields/name';
+// import * as fieldRadio from './blocks/form/fields/radio';
+// import * as fieldTelephone from './blocks/form/fields/phone';
+// import * as fieldTextarea from './blocks/form/fields/textarea';
+// import * as fieldText from './blocks/form/fields/text';
+// import * as fieldSelect from './blocks/form/fields/select';
+// import * as fieldSubmitButton from './blocks/form/fields/submit-button';
+// import * as fieldCheckbox from './blocks/form/fields/checkbox';
+// import * as fieldWebsite from './blocks/form/fields/website';
+// import * as fieldHidden from './blocks/form/fields/hidden';
+// import * as gif from './blocks/gif';
+// import * as gist from './blocks/gist';
+// WP.com custom - END
 import * as hero from './blocks/hero';
-import * as highlight from './blocks/highlight';
-import * as icon from './blocks/icon';
+// WP.com custom - START
+// import * as highlight from './blocks/highlight';
+// import * as icon from './blocks/icon';
+// WP.com custom - END
 import * as logos from './blocks/logos';
-import * as map from './blocks/map';
+// WP.com custom - START
+// import * as map from './blocks/map';
+// WP.com custom - END
 import * as masonry from './blocks/gallery-masonry';
-import * as mediaCard from './blocks/media-card';
+// WP.com custom - START
+// import * as mediaCard from './blocks/media-card';
+// WP.com custom - END
 import * as offset from './blocks/gallery-offset';
-import * as posts from './blocks/posts';
-import * as postCarousel from './blocks/post-carousel';
+// WP.com custom - START
+// import * as posts from './blocks/posts';
+// import * as postCarousel from './blocks/post-carousel';
+// WP.com custom - END
 import * as pricingTable from './blocks/pricing-table';
 import * as pricingTableItem from './blocks/pricing-table/pricing-table-item';
-import * as row from './blocks/row';
-import * as service from './blocks/services/service';
-import * as services from './blocks/services';
-import * as shapeDivider from './blocks/shape-divider';
-import * as share from './blocks/share';
-import * as socialProfiles from './blocks/social-profiles';
+// WP.com custom - START
+// import * as row from './blocks/row';
+// import * as services from './blocks/services';
+// import * as service from './blocks/services/service';
+// import * as shapeDivider from './blocks/shape-divider';
+// import * as share from './blocks/share';
+// import * as socialProfiles from './blocks/social-profiles';
+// WP.com custom - END
 import * as stacked from './blocks/gallery-stacked';
 
 /**
@@ -101,9 +135,38 @@ const registerBlock = ( block ) => {
 
 	const { name, settings } = block;
 
-	if ( ! supportsCollections() && ! name.includes( 'gallery' ) ) {
-		category = 'coblocks';
+	// WP.com custom - START
+	//if ( ! supportsCollections() && ! name.includes( 'gallery' ) ) {
+	//	category = 'coblocks';
+	//}
+
+	// See https://github.com/Automattic/jetpack/issues/14598
+	const availableCategories = wp.blocks.getCategories().map( category => category.slug );
+	switch ( name ) {
+		case 'coblocks/click-to-tweet':
+		case 'coblocks/logos':
+			if ( availableCategories.indexOf( 'grow' ) > -1 ) {
+				category = 'grow';
+			}
+			break;
+
+		case 'coblocks/pricing-table':
+			if ( availableCategories.indexOf( 'earn' ) > -1 ) {
+				category = 'earn';
+			}
+			break;
+
+		case 'coblocks/buttons':
+		case 'coblocks/dynamic-separator':
+		case 'coblocks/gallery-collage':
+		case 'coblocks/gallery-masonry':
+		case 'coblocks/gallery-offset':
+		case 'coblocks/gallery-stacked':
+		case 'coblocks/hero':
+			category = 'layout';
+			break;
 	}
+	// WP.com custom - END
 
 	registerBlockType( name, {
 		category,
@@ -116,55 +179,73 @@ const registerBlock = ( block ) => {
  */
 export const registerCoBlocksBlocks = () => {
 	[
-		accordion,
-		accordionItem,
-		alert,
-		author,
+		// WP.com custom - START
+		// accordion,
+		// accordionItem,
+		// alert,
+		// author,
+		// WP.com custom - END
 		buttons,
-		carousel,
+		// WP.com custom - START
+		// carousel,
+		// WP.com custom - END
 		clickToTweet,
 		collage,
-		column,
+		// WP.com custom - START
+		// column,
+		// WP.com custom - END
 		dynamicSeparator,
-		events,
-		eventItem,
-		feature,
-		features,
-		fieldDate,
-		fieldEmail,
-		fieldName,
-		fieldRadio,
-		fieldTelephone,
-		fieldTextarea,
-		fieldText,
-		fieldSelect,
-		fieldSubmitButton,
-		fieldCheckbox,
-		fieldWebsite,
-		fieldHidden,
-		foodAndDrinks,
-		foodItem,
-		form,
-		gif,
-		gist,
+		// WP.com custom - START
+		// events,
+		// eventItem,
+		// feature,
+		// features,
+		// fieldDate,
+		// fieldEmail,
+		// fieldName,
+		// fieldRadio,
+		// fieldTelephone,
+		// fieldTextarea,
+		// fieldText,
+		// fieldSelect,
+		// fieldSubmitButton
+		// fieldCheckbox,
+		// fieldWebsite,
+		// fieldHidden,
+		// foodAndDrinks,
+		// foodItem,
+		// form,
+		// gif,
+		// gist,
+		// WP.com custom - END
 		hero,
-		highlight,
-		icon,
+		// WP.com custom - START
+		// highlight,
+		// icon,
+		// WP.com custom - END
 		logos,
-		map,
+		// WP.com custom - START
+		// map,
+		// WP.com custom - END
 		masonry,
-		mediaCard,
+		// WP.com custom - START
+		// mediaCard,
+		// WP.com custom - END
 		offset,
-		posts,
-		postCarousel,
+		// WP.com custom - START
+		// posts,
+		// postCarousel,
+		// WP.com custom - END
 		pricingTable,
 		pricingTableItem,
-		row,
-		service,
-		services,
-		shapeDivider,
-		share,
-		socialProfiles,
+		// WP.com custom - START
+		// row,
+		// service,
+		// services,
+		// shapeDivider,
+		// share,
+		// socialProfiles,
+		// WP.com custom - END
 		stacked,
 	].forEach( registerBlock );
 };

--- a/src/blocks.js
+++ b/src/blocks.js
@@ -2,14 +2,11 @@
  * WordPress dependencies
  */
 import {
-	// WP.com custom - START
 	getCategories,
-	// WP.com custom - END
 	registerBlockType,
 } from '@wordpress/blocks';
-// WP.com custom - START
+
 import { __, sprintf } from '@wordpress/i18n';
-// WP.com custom - END
 
 // Register block category
 import './utils/block-category';
@@ -57,7 +54,6 @@ const registerBlock = ( block ) => {
 
 	const { name, settings } = block;
 
-	// WP.com custom - START
 	// See https://github.com/Automattic/jetpack/issues/14598
 	const availableCategories = wp.blocks.getCategories().map( category => category.slug );
 	switch ( name ) {
@@ -84,7 +80,6 @@ const registerBlock = ( block ) => {
 			category = 'layout';
 			break;
 	}
-	// WP.com custom - END
 
 	registerBlockType( name, {
 		category,

--- a/src/blocks.js
+++ b/src/blocks.js
@@ -55,7 +55,7 @@ const registerBlock = ( block ) => {
 	const { name, settings } = block;
 
 	// See https://github.com/Automattic/jetpack/issues/14598
-	const availableCategories = wp.blocks.getCategories().map( category => category.slug );
+	const availableCategories = getCategories().map( category => category.slug );
 	switch ( name ) {
 		case 'coblocks/click-to-tweet':
 		case 'coblocks/logos':

--- a/src/blocks/pricing-table/controls.js
+++ b/src/blocks/pricing-table/controls.js
@@ -57,12 +57,6 @@ class Controls extends Component {
 						value={ contentAlign }
 						onChange={ ( nextContentAlign ) => setAttributes( { contentAlign: nextContentAlign } ) }
 					/>
-          {
-            /**
-             * Using ToolbarGroup to make controls render.
-             * See https://github.com/godaddy-wordpress/coblocks/issues/1670
-             */
-          }
 					<ToolbarGroup
 						isCollapsed={ true }
 						icon={ activeCount.icon }

--- a/src/blocks/pricing-table/controls.js
+++ b/src/blocks/pricing-table/controls.js
@@ -59,13 +59,11 @@ class Controls extends Component {
 					/>
           {
             /**
-             * WP.com custom - START
              * Using ToolbarGroup to make controls render.
              * See https://github.com/godaddy-wordpress/coblocks/issues/1670
              */
           }
 					<ToolbarGroup
-            // WP.com custom - END
 						isCollapsed={ true }
 						icon={ activeCount.icon }
 						label={ __( 'Change pricing table count', 'coblocks' ) }

--- a/src/blocks/pricing-table/controls.js
+++ b/src/blocks/pricing-table/controls.js
@@ -9,7 +9,7 @@ import { find } from 'lodash';
 import { __ } from '@wordpress/i18n';
 import { Component, Fragment } from '@wordpress/element';
 import { AlignmentToolbar, BlockControls } from '@wordpress/block-editor';
-import { Toolbar, Path, SVG } from '@wordpress/components';
+import { ToolbarGroup, Path, SVG } from '@wordpress/components';
 
 const DEFAULT_ALIGNMENT_CONTROLS = [
 	{
@@ -57,7 +57,15 @@ class Controls extends Component {
 						value={ contentAlign }
 						onChange={ ( nextContentAlign ) => setAttributes( { contentAlign: nextContentAlign } ) }
 					/>
-					<Toolbar
+          {
+            /**
+             * WP.com custom - START
+             * Using ToolbarGroup to make controls render.
+             * See https://github.com/godaddy-wordpress/coblocks/issues/1670
+             */
+          }
+					<ToolbarGroup
+            // WP.com custom - END
 						isCollapsed={ true }
 						icon={ activeCount.icon }
 						label={ __( 'Change pricing table count', 'coblocks' ) }


### PR DESCRIPTION
**Issue:** https://github.com/Automattic/wp-calypso/issues/46935

#### What

Bring the WPCOM-specific mods over to the fork. For now, the code modifications have been moved verbatim, but the idea is to remove the comments and any commented-out code soon. Based on the modifications in `coblocks-builder`. 

#### How to test

##### WPCOM

1. Checkout this branch;
1. Run: `composer install && yarn && yarn build` to build coblocks;
1. Login to your sandbox 
1. rync the whole folder to your sandbox: `rsync -azP . --exclude .git --exclude node_modules user@sandbox:~/public_html/wp-content/plugins/coblocks/test`
1. Set the coblocks version used to `test` in the coblocks loader file. Which var to change will depend on whether the site has the coblocks-edge sticker applied or not.
1. Add or edit a post or page, make sure that the coblocks works well and that only the following blocks are available: "Click To Tweet", "Collage", "Dynamic HR", "Hero", "Logo", "Masonry", "Offset", "Pricing Table", "Stacked".

##### AT

1. Follow steps 1 to 2 above to build the plugin;
1. Zip the contents of the folder;
1. Create an AT site from a simple site;
1. Activate the SFTP user in the Calypso UI;
1. SFTP to your site and remove the coblocks symlink in `/htdocs/wp-content/plugins/coblocks`;
1. You should now be able to upload the coblocks zip from wp-admin plugin UI, here: https://yoursite.wpcomstaging.com/wp-admin/plugin-install.php (click the "Upload plugin" button, browse for the zip you just created and upload);
1. Add or edit a post or page, make sure that the coblocks works well and that only the following blocks are available: "Click To Tweet", "Collage", "Dynamic HR", "Hero", "Logo", "Masonry", "Offset", "Pricing Table", "Stacked".


#### Related PRs

* #2
* #3
* #4
* #5
