### PR TITLE
Prevent webpack from building entry point files that are not needed anymore

### DIFF
--- a/.dev/config/webpack.config.js
+++ b/.dev/config/webpack.config.js
@@ -17,20 +17,13 @@ module.exports = {
 		'coblocks-editor': path.resolve( process.cwd(), 'src/styles/editor.scss' ),
 		'coblocks-style': path.resolve( process.cwd(), 'src/styles/style.scss' ),
 
-		'js/coblocks-accordion-polyfill': path.resolve( process.cwd(), 'src/js/coblocks-accordion-polyfill.js' ),
 		'js/coblocks-accordion-carousel': path.resolve( process.cwd(), 'src/js/coblocks-accordion-carousel.js' ),
 		'js/coblocks-datepicker': path.resolve( process.cwd(), 'src/js/coblocks-datepicker.js' ),
 		'js/coblocks-events': path.resolve( process.cwd(), 'src/js/coblocks-events.js' ),
-		'js/coblocks-fromEntries': path.resolve( process.cwd(), 'src/js/coblocks-fromEntries.js' ),
-		'js/coblocks-google-maps': path.resolve( process.cwd(), 'src/js/coblocks-google-maps.js' ),
-		'js/coblocks-google-recaptcha': path.resolve( process.cwd(), 'src/js/coblocks-google-recaptcha.js' ),
 		'js/coblocks-lightbox': path.resolve( process.cwd(), 'src/js/coblocks-lightbox.js' ),
 		'js/coblocks-masonry': path.resolve( process.cwd(), 'src/js/coblocks-masonry.js' ),
 		'js/coblocks-slick-initializer': path.resolve( process.cwd(), 'src/js/coblocks-slick-initializer.js' ),
 		'js/coblocks-slick-initializer-front': path.resolve( process.cwd(), 'src/js/coblocks-slick-initializer-front.js' ),
-
-		'js/vendors/flickity': path.resolve( process.cwd(), 'node_modules/flickity/dist/flickity.pkgd.js' ),
-		'js/vendors/slick': path.resolve( process.cwd(), 'node_modules/slick-carousel/slick/slick.js' ),
 	},
 
 	output: {


### PR DESCRIPTION
Issue: https://github.com/Automattic/wp-calypso/issues/46935

#### What

Prevent webpack from building entry point files that are not needed anymore. Based on the modifications in `coblocks-builder`. 

#### How to test

##### WPCOM

1. Checkout this branch;
1. Run: `composer install && npm install && npm run build` to build coblocks;
1. Login to your sandbox 
1. rync the whole folder to your sandbox: `rsync -azP . --exclude .git --exclude node_modules user@sandbox:~/public_html/wp-content/plugins/coblocks/test`
1. Set the coblocks version used to `test` in the coblocks loader file. Which var to change will depend on whether the site has the coblocks-edge sticker applied or not.
1. Add or edit a post or page, make sure that that coblocks loads properly and doesn't catastrophically crash. Smoke test using the allowed blocks.

##### AT

1. Follow steps 1 to 2 above to build the plugin;
1. Zip the contents of the folder;
1. Create an AT site from a simple site;
1. Activate the SFTP user in the Calypso UI;
1. SFTP to your site and remove the coblocks symlink in `/htdocs/wp-content/plugins/coblocks`;
1. You should now be able to upload the coblocks zip from wp-admin plugin UI, here: https://yoursite.wpcomstaging.com/wp-admin/plugin-install.php (click the "Upload plugin" button, browse for the zip you just created and upload);
1. Add or edit a post or page, make sure that that coblocks loads properly and doesn't catastrophically crash. Smoke test using the allowed blocks.

#### Related PRs

* #1
* #2
* #4
* #5