### PR TITLE
Add mu-plugins loader for Atomic

### DIFF
--- a/coblocks-loader.php
+++ b/coblocks-loader.php
@@ -1,0 +1,25 @@
+<?php
+
+/**
+ * Plugin Name: CoBlocks
+ * Description: Custom WordPress.com CoBlocks fork.
+ *
+ * Our CoBlocks fork is a mu-plugin and it's loaded by default using this loader.
+ * This includes additional logic to check if another version of CoBlocks is
+ * present. If that's the case, it'll take precedence over this one.
+ **/
+if ( defined( 'IS_ATOMIC' ) && IS_ATOMIC ) {
+  function load_coblocks() {
+    $load_mu_coblocks = function() { require_once( WPMU_PLUGIN_DIR . '/coblocks/class-coblocks.php' ); };
+
+    $is_activating_coblocks = (isset($_GET['action']) && isset($_GET['plugin'])) &&
+      ($_GET['action'] == 'activate' && $_GET['plugin'] == 'coblocks/class-coblocks.php');
+
+    $official_coblocks_present = in_array('coblocks/class-coblocks.php', get_option('active_plugins'), TRUE);
+
+    if (!$is_activating_coblocks && !$official_coblocks_present) {
+      $load_mu_coblocks();
+    }
+  }
+  add_action( 'plugins_loaded', 'load_coblocks' );
+}

--- a/coblocks-loader.php
+++ b/coblocks-loader.php
@@ -8,6 +8,9 @@
  * This includes additional logic to check if another version of CoBlocks is
  * present. If that's the case, it'll take precedence over this one.
  **/
+
+namespace A8C_CoBlocks;
+
 if ( defined( 'IS_ATOMIC' ) && IS_ATOMIC ) {
   function load_coblocks() {
     $load_mu_coblocks = function() { require_once( WPMU_PLUGIN_DIR . '/coblocks/class-coblocks.php' ); };
@@ -21,5 +24,5 @@ if ( defined( 'IS_ATOMIC' ) && IS_ATOMIC ) {
       $load_mu_coblocks();
     }
   }
-  add_action( 'plugins_loaded', 'load_coblocks' );
+  add_action( 'plugins_loaded', __NAMESPACE__ . '\load_coblocks' );
 }


### PR DESCRIPTION
**Issue:** https://github.com/Automattic/wp-calypso/issues/46935

#### What

Add a `mu-plugins` loader that to be used by the AT platform.

The fork is loaded as a `mu-plugin`, which means that it's hidden from the list of plugins so most users will not even realize the actual fork is installed.

However, users might want to install the official full-blown version of CoBlocks and that shouldn't cause any errors or issues. The loader implements that by making sure that the mu fork is not loaded if a regular CoBlocks plugin is detected. (See related discussion here: pc9Uba-7N-p2#comment-205.

I've followed the same pattern `wpcomsh` uses: the loader is included as part of the repo, and to use it, you should symlink or copy it to the root of the `mu-plugins` directory.

#### How to test

The following instructions are specific to AT but can be easily adapted to a local org instance (i.e wp-env) if you'd like. I wanted to test on AT to be closer to production.

1. Checkout this branch;
1. Run: `composer install && npm install && npm run build` to build coblocks;
1. Remove the .git and node-modules folder
1. Create an AT site out of a simple site (upgrade to the business plan, install a plugin);
1. Create an AT site from a simple site;
1. Activate the SFTP user in the Calypso UI;
1. SFTP to your site and upload your the build of Coblocks you created in step 2) over to `/htdocs/wp-content/mu-plugins`. This will take some time, I recommned using an app like FileZila, it's still slow but faster than `sftp`.
1. Now use SFTP again to copy `coblocks-loader.php` from the root of your build to `/htdocs/wp-content/mu-plugins`
1. Make sure the the pre-installed CoBlocks instance (should be the latest version) activated;
1. Create or edit a post, check the available coblocks blocks -- all blocks should be there, which means the plugin version took precedence;
1. Now de-activate the plugin version and reload the post. You should see only the 9 blocks that are available in the custom fork ("Click To Tweet", "Collage", "Dynamic HR", "Hero", "Logo", "Masonry", "Offset", "Pricing Table", "Stacked"), which means the mu-plugin version has loaded.

### Screecast

I recorded a [screencast](http://www.youtube.com/watch?v=rfruWbhx2P8) where I test the scenarios described above.

#### Outstanding questions 

We didn't use the `is_plugin_active` because of some inconsistencies we found while using it, see this discussion on Slack: p1604949278016400-slack-C017FDWM21W?thread_ts=1604635354.005000&cid=C017FDWM21W.

However, the source for `is_plugin_active` [includes](https://developer.wordpress.org/reference/functions/is_plugin_active/#source) a call to `is_plugin_active_for_network`. The documentation for this function doesn't elaborate on what "network" means in this context. I don't know why this is needed, is it related to multi-site setups? We might need to translate that into our condition [here](https://github.com/Automattic/coblocks/pull/5/files#diff-e54235ddd3f8084cd6a0748b34ad4c63c23577b8b369d47e766a042817883e61R18). 

#### Related PRs

* #1
* #2
* #3
* #4